### PR TITLE
Fix setuptools package data pattern

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ package-dir = {"" = "src"}
 where = ["src"]
 
 [tool.setuptools.package-data]
-wedm = ["data/*.json", "modules/data/*.json"]
+wedm = ["data/*.json", "modules/*.json"]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
## Summary
- include JSON files in modules folder when packaging

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684814f6e9c083318aaceb10e2d7b477