### PR TITLE
Fix path in installation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Thank you for your interest in contributing to the Wire EDM Learning Environment
 ```bash
 # Clone the repository
 git clone https://github.com/geduardo/WEDM-Learning-Environment.git
-cd WEDM-Learning-Environment
+cd SPARC
 
 # Install in development mode with dev dependencies
 pip install -e ".[dev,visualization]"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install wedm-learning-environment
 ```bash
 # Clone the repository
 git clone https://github.com/geduardo/SPARC.git
-cd WEDM-Learning-Environment
+cd SPARC
 
 # Install in development mode
 pip install -e .


### PR DESCRIPTION
## Summary
- update docs to use `cd SPARC` when installing from source

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68481500a9188331aca645317ef01196