### PR TITLE
Add env state time progression assertion

### DIFF
--- a/tests/test_env_integration.py
+++ b/tests/test_env_integration.py
@@ -28,9 +28,11 @@ class TestWireEDMEnv:
         """Test environment step with random action."""
         env = WireEDMEnv()
         env.reset()
+        initial_time = env.state.time
 
         action = env.action_space.sample()
         obs, reward, terminated, truncated, info = env.step(action)
+        assert env.state.time > initial_time
 
         assert isinstance(reward, (int, float))
         assert isinstance(terminated, bool)


### PR DESCRIPTION
## Summary
- verify that stepping the environment advances time in the integration test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848150b37ec8331a8db8969ba4e8491