### PR TITLE
Fix LaTeX delimiters in theory docs

### DIFF
--- a/docs/theory/ignition_theory.md
+++ b/docs/theory/ignition_theory.md
@@ -26,45 +26,45 @@ The state transitions follow this sequence:
 Mathematically, these transitions can be represented as:
 
 For Idle to ON transition (stochastic ignition):
-\[
+$$
 P(\text{Idle} \rightarrow \text{ON}) = P_{ignite} = \lambda(gap)
-\]
+$$
 
 For ON to OFF transition (deterministic):
-\[
+$$
 \text{If } t_{spark} \geq t_{ON} \text{ then } \text{ON} \rightarrow \text{OFF}
-\]
+$$
 
 For OFF to Idle transition (deterministic):
-\[
+$$
 \text{If } t_{total} \geq (t_{ON} + t_{OFF}) \text{ then } \text{OFF} \rightarrow \text{Idle}
-\]
+$$
 
 Where:
-- \(P_{ignite}\): Probability of ignition
-- \(\lambda(gap)\): Gap-dependent ignition probability function
-- \(t_{spark}\): Duration of the current spark
-- \(t_{total}\): Total duration since spark initiation (ON + OFF time elapsed)
-- \(t_{ON}\): ON time setting
-- \(t_{OFF}\): OFF time setting
+- $P_{ignite}$: Probability of ignition
+- $\lambda(gap)$: Gap-dependent ignition probability function
+- $t_{spark}$: Duration of the current spark
+- $t_{total}$: Total duration since spark initiation (ON + OFF time elapsed)
+- $t_{ON}$: ON time setting
+- $t_{OFF}$: OFF time setting
 
 ## Ignition Probability Model
 
-The probability of a spark ignition during the idle state is calculated using a gap-dependent function \(\lambda(gap)\). This function represents the ignition probability per time step and is derived from empirical data.
+The probability of a spark ignition during the idle state is calculated using a gap-dependent function $\lambda(gap)$. This function represents the ignition probability per time step and is derived from empirical data.
 
-\[
+$$
 \lambda(gap) = \frac{\ln(2)}{0.48 \cdot gap^2 - 3.69 \cdot gap + 14.05}
-\]
+$$
 
 Where:
-- \(gap\): Distance between the wire and workpiece (mm)
-- \(\ln(2)\): Natural logarithm of 2, used to normalize the probability
+- $gap$: Distance between the wire and workpiece (mm)
+- $\ln(2)$: Natural logarithm of 2, used to normalize the probability
 
-For computational efficiency, the module caches the calculated \(\lambda\) values for different gap sizes.
+For computational efficiency, the module caches the calculated $\lambda$ values for different gap sizes.
 
 ## Short Circuit Handling
 
-A short circuit occurs when the wire touches the workpiece (\(gap \leq 0\)). The module handles short circuits with special logic:
+A short circuit occurs when the wire touches the workpiece ($gap \leq 0$). The module handles short circuits with special logic:
 
 1. If the system is in the idle state (0) and a short circuit occurs, it immediately transitions to the ON state (1) with full current and zero voltage.
 2. During short circuit conditions, the ignition probability calculation is skipped (returns 0) to prevent mathematical errors due to non-positive gap values.
@@ -74,40 +74,40 @@ A short circuit occurs when the wire touches the workpiece (\(gap \leq 0\)). The
 During different states, the electrical parameters are set as follows:
 
 ### Idle State (0):
-- Current: \(I = 0\)
-- Voltage: \(V = V_{target}\) (if not shorted), \(V = 0\) (if shorted)
+- Current: $I = 0$
+- Voltage: $V = V_{target}$ (if not shorted), $V = 0$ (if shorted)
 
 ### ON State (1):
-- Current: \(I = I_{peak}\)
-- Voltage: \(V = 0.3 \cdot V_{target}\) (if not shorted), \(V = 0\) (if shorted)
+- Current: $I = I_{peak}$
+- Voltage: $V = 0.3 \cdot V_{target}$ (if not shorted), $V = 0$ (if shorted)
 
 ### OFF State (-2):
-- Current: \(I = 0\)
-- Voltage: \(V = 0\)
+- Current: $I = 0$
+- Voltage: $V = 0$
 
 Where:
-- \(I_{peak}\): Peak current setting (default: 300A)
-- \(V_{target}\): Target voltage setting (default: 80V)
+- $I_{peak}$: Peak current setting (default: 300A)
+- $V_{target}$: Target voltage setting (default: 80V)
 
 ## Stochastic Ignition Process
 
 For each time step in the idle state, the module:
 
-1. Calculates the ignition probability \(P_{ignite}\) based on the current gap
-2. Generates a random number \(r \in [0,1]\)
-3. If \(r < P_{ignite}\), a spark is initiated:
+1. Calculates the ignition probability $P_{ignite}$ based on the current gap
+2. Generates a random number $r \in [0,1]$
+3. If $r < P_{ignite}$, a spark is initiated:
    - A random spark location along the workpiece height is chosen
    - The system transitions to the ON state
    - The electrical parameters are updated accordingly
 
 Mathematically:
-\[
+$$
 \text{If } r < \lambda(gap) \text{ then initiate spark at random location}
-\]
+$$
 
 ## Implementation Details
 
-- The module caches \(\lambda\) values for efficiency using a dictionary `lambda_cache`
+- The module caches $\lambda$ values for efficiency using a dictionary `lambda_cache`
 - The primary `update` method handles the state machine transitions and updates the electrical parameters
 - The `_cond_prob` method calculates the conditional probability of ignition based on the current gap
 - The `get_lambda` method computes the gap-dependent ignition probability function

--- a/docs/theory/material_theory.md
+++ b/docs/theory/material_theory.md
@@ -19,42 +19,42 @@ In WEDM, material removal occurs through the following physical process:
 
 ### Crater Volume Model
 
-The module models crater volumes using empirical distributions based on discharge current. Each crater volume \(V_c\) is sampled from a Gaussian distribution:
+The module models crater volumes using empirical distributions based on discharge current. Each crater volume $V_c$ is sampled from a Gaussian distribution:
 
-\[
+$$
 V_c \sim \mathcal{N}(\mu_I, \sigma_I^2)
-\]
+$$
 
 Where:
-- \(\mu_I\): Mean crater volume for current \(I\) (μm³)
-- \(\sigma_I\): Standard deviation of crater volume for current \(I\) (μm³)
-- \(I\): Discharge current (A)
+- $\mu_I$: Mean crater volume for current $I$ (μm³)
+- $\sigma_I$: Standard deviation of crater volume for current $I$ (μm³)
+- $I$: Discharge current (A)
 
-The empirical parameters \(\mu_I\) and \(\sigma_I\) are derived from experimental measurements and stored in the crater volume database.
+The empirical parameters $\mu_I$ and $\sigma_I$ are derived from experimental measurements and stored in the crater volume database.
 
 ### Workpiece Position Calculation
 
-The workpiece position increment \(\Delta X_w\) for each crater is calculated using the relationship:
+The workpiece position increment $\Delta X_w$ for each crater is calculated using the relationship:
 
-\[
+$$
 \Delta X_w = \frac{V_c}{k \cdot h_w}
-\]
+$$
 
 Where:
-- \(V_c\): Crater volume (mm³)
-- \(k\): Kerf width (mm)
-- \(h_w\): Workpiece height (mm)
+- $V_c$: Crater volume (mm³)
+- $k$: Kerf width (mm)
+- $h_w$: Workpiece height (mm)
 
-The kerf width \(k\) is a critical parameter and is determined by the wire diameter, a base overcut, and the depth of the discharge crater. It is calculated as:
+The kerf width $k$ is a critical parameter and is determined by the wire diameter, a base overcut, and the depth of the discharge crater. It is calculated as:
 
-\[
+$$
 k = D_w + k_{base} + \frac{d_{crater,μm}}{1000}
-\]
+$$
 
 Where:
-- \(D_w\): Wire diameter (mm)
-- \(k_{base} = 0.12\) mm: Base overcut, representing the minimum symmetrical discharge gap around the wire (0.06 mm per side)
-- \(d_{crater,μm}\): Crater depth for the current discharge setting (μm), obtained from empirical data
+- $D_w$: Wire diameter (mm)
+- $k_{base} = 0.12$ mm: Base overcut, representing the minimum symmetrical discharge gap around the wire (0.06 mm per side)
+- $d_{crater,μm}$: Crater depth for the current discharge setting (μm), obtained from empirical data
 
 This formulation provides a physically grounded kerf width that incorporates the fixed dimension of the wire, a minimum operational overcut, and a dynamic component related to the discharge energy (via crater depth).
 
@@ -78,15 +78,15 @@ The WEDM machine operates with predefined current modes (I1 through I19) that co
 
 The empirical crater data is available for specific current levels: [1, 3, 5, 7, 9, 11, 13, 15, 17] A. To map machine currents to available crater data, the module uses a scaling approach:
 
-\[
+$$
 I_{crater} = I_{available}[\lfloor r \cdot (N-1) \rfloor]
-\]
+$$
 
 Where:
-- \(r = \frac{I_{machine} - I_{min}}{I_{max} - I_{min}}\): Relative position in machine current range
-- \(I_{min} = 30\) A, \(I_{max} = 600\) A: Machine current range
-- \(I_{available}\): Array of available crater data currents
-- \(N = 9\): Number of available crater data points
+- $r = \frac{I_{machine} - I_{min}}{I_{max} - I_{min}}$: Relative position in machine current range
+- $I_{min} = 30$ A, $I_{max} = 600$ A: Machine current range
+- $I_{available}$: Array of available crater data currents
+- $N = 9$: Number of available crater data points
 
 ## Empirical Crater Data
 
@@ -104,11 +104,11 @@ The crater volume data contains the following parameters for each current level:
 
 The module uses the half-ellipsoid volume model, which provides realistic crater volumes based on experimental observations:
 
-\[
+$$
 V_{ellipsoid\_half} = \frac{2}{3} \pi \cdot a \cdot b \cdot c
-\]
+$$
 
-Where \(a\), \(b\), and \(c\) are the semi-axes of the ellipsoid derived from the crater area and depth measurements.
+Where $a$, $b$, and $c$ are the semi-axes of the ellipsoid derived from the crater area and depth measurements.
 
 ### Current-Volume Relationship
 
@@ -152,38 +152,38 @@ The module handles multiple unit systems with appropriate conversion factors:
 - **Position increments**: Converted from mm (calculation) to μm (state)
 
 The conversion factors are:
-- μm³ to mm³: divide by \(10^9\)
-- μm to mm: divide by \(10^3\)
-- mm to μm: multiply by \(10^3\)
+- μm³ to mm³: divide by $10^9$
+- μm to mm: divide by $10^3$
+- mm to μm: multiply by $10^3$
 
 ## Mathematical Formulation Summary
 
 The complete material removal process can be summarized as:
 
 1. **Current Mapping**:
-   \[
+   $$
    I_{crater} = f_{map}(I_{machine})
-   \]
+   $$
 
 2. **Crater Volume Sampling**:
-   \[
+   $$
    V_c \sim \mathcal{N}(\mu_{I_{crater}}, \sigma_{I_{crater}}^2)
-   \]
+   $$
 
 3. **Kerf Width Calculation**:
-   \[
+   $$
    k = D_w + k_{base} + \frac{d_{crater,μm}}{1000}
-   \]
+   $$
 
 4. **Position Increment**:
-   \[
+   $$
    \Delta X_w = \frac{V_c \cdot 10^{-9}}{k \cdot h_w} \cdot 1000
-   \]
+   $$
 
 5. **Workpiece Position Update**:
-   \[
+   $$
    X_{w,new} = X_{w,old} + \Delta X_w
-   \]
+   $$
 
 ## Key Variables
 

--- a/docs/theory/mechanics_theory.md
+++ b/docs/theory/mechanics_theory.md
@@ -17,42 +17,42 @@ Both control strategies must account for the mechanical limitations of the servo
 
 The position control system uses a 2nd-order servo model with proportional-derivative (PD) control characteristics:
 
-\[
+$$
 a_{nom} = -2\zeta\omega v_{wire} - \omega^2(x_{wire} - \color{blue}{x_{commanded}})
-\]
-\[
+$$
+$$
 \ddot{x}_{wire} + 2\zeta\omega \dot{x}_{wire} + \omega^2 (x_{wire} - x_{commanded}) = 0
-\]
+$$
 
 
 Where:
-- \(a_{nom}\): Nominal acceleration command [µm/s²]
-- \(\zeta\): Damping ratio (dimensionless)
-- \(\omega\): Natural frequency [rad/s]
-- \(v\): Current wire velocity [µm/s]
-- \(x\): Current wire position [µm]
-- \(x_{tgt}\): Target wire position [µm]
+- $a_{nom}$: Nominal acceleration command [µm/s²]
+- $\zeta$: Damping ratio (dimensionless)
+- $\omega$: Natural frequency [rad/s]
+- $v$: Current wire velocity [µm/s]
+- $x$: Current wire position [µm]
+- $x_{tgt}$: Target wire position [µm]
 
 ### System Dynamics
 
 This control law represents a critically damped 2nd-order system where:
 
-- **Proportional term**: \(-\omega_n^2(x - x_{tgt})\) provides restoring force proportional to position error
-- **Derivative term**: \(-2\zeta\omega_n v\) provides damping proportional to velocity
+- **Proportional term**: $-\omega_n^2(x - x_{tgt})$ provides restoring force proportional to position error
+- **Derivative term**: $-2\zeta\omega_n v$ provides damping proportional to velocity
 
 The transfer function of this system in the Laplace domain is:
-\[
+$$
 G(s) = \frac{\omega_n^2}{s^2 + 2\zeta\omega_n s + \omega_n^2}
-\]
+$$
 
 ### Target Interpretation
 
 In position control mode:
-\[
+$$
 x_{tgt} = x_{current} + \Delta x_{target}
-\]
+$$
 
-Where `state.target_delta` represents the desired position increment \(\Delta x_{target}\) [µm].
+Where `state.target_delta` represents the desired position increment $\Delta x_{target}$ [µm].
 
 ## Velocity Control System (`MechanicsVelocityModule`)
 
@@ -60,40 +60,40 @@ Where `state.target_delta` represents the desired position increment \(\Delta x_
 
 The velocity control system uses a 1st-order servo model with proportional control:
 
-\[
+$$
 a_{nom} = -\omega_n(v_{wire} - \color{blue}{v_{commanded}})
-\]
+$$
 
 Where:
-- \(a_{nom}\): Nominal acceleration command [µm/s²]
-- \(\omega_n\): Control bandwidth [rad/s]
-- \(v\): Current wire velocity [µm/s]
-- \(v_{tgt}\): Target wire velocity [µm/s]
+- $a_{nom}$: Nominal acceleration command [µm/s²]
+- $\omega_n$: Control bandwidth [rad/s]
+- $v$: Current wire velocity [µm/s]
+- $v_{tgt}$: Target wire velocity [µm/s]
 
 ### System Dynamics
 
 This control law represents a 1st-order system where:
 
-- **Proportional term**: \(-\omega_n(v - v_{tgt})\) provides acceleration proportional to velocity error
+- **Proportional term**: $-\omega_n(v - v_{tgt})$ provides acceleration proportional to velocity error
 
 The transfer function of this system in the Laplace domain is:
-\[
+$$
 G(s) = \frac{\omega_n}{s + \omega_n}
-\]
+$$
 
 The time constant of the system is:
-\[
+$$
 \tau = \frac{1}{\omega_n}
-\]
+$$
 
 ### Target Interpretation
 
 In velocity control mode:
-\[
+$$
 v_{tgt} = \Delta v_{target}
-\]
+$$
 
-Where `state.target_delta` directly represents the desired target velocity \(\Delta v_{target}\) [µm/s].
+Where `state.target_delta` directly represents the desired target velocity $\Delta v_{target}$ [µm/s].
 
 ## Physical Constraints and Limiting
 
@@ -102,75 +102,75 @@ Both control systems implement realistic physical constraints to model actual se
 ### Acceleration Limiting
 
 The nominal acceleration is constrained to realistic values:
-\[
+$$
 a_{constrained} = \text{clip}(a_{nom}, -a_{max}, a_{max})
-\]
+$$
 
-Where \(a_{max}\) is the maximum acceleration capability [µm/s²].
+Where $a_{max}$ is the maximum acceleration capability [µm/s²].
 
 ### Jerk Limiting
 
 To prevent unrealistic instantaneous acceleration changes, jerk limiting is applied:
-\[
+$$
 \frac{da}{dt} = \text{clip}\left(\frac{a_{constrained} - a_{prev}}{\Delta t}, -j_{max}, j_{max}\right)
-\]
+$$
 
 The actual acceleration becomes:
-\[
+$$
 a_{actual} = a_{prev} + \frac{da}{dt} \cdot \Delta t
-\]
+$$
 
 Where:
-- \(a_{prev}\): Previous acceleration [µm/s²]
-- \(j_{max}\): Maximum jerk [µm/s³]
-- \(\Delta t\): Time step [s]
+- $a_{prev}$: Previous acceleration [µm/s²]
+- $j_{max}$: Maximum jerk [µm/s³]
+- $\Delta t$: Time step [s]
 
 ### Velocity Limiting
 
 The velocity is constrained to maximum achievable values:
-\[
+$$
 v_{constrained} = \text{clip}(v_{updated}, -v_{max}, v_{max})
-\]
+$$
 
-Where \(v_{max}\) is the maximum velocity capability [µm/s].
+Where $v_{max}$ is the maximum velocity capability [µm/s].
 
 ## Integration and State Updates
 
 Both systems use explicit Euler integration to update the state variables:
 
 ### Velocity Update
-\[
+$$
 v(t + \Delta t) = v_{wire}(t) + a_{actual} \cdot \Delta t
-\]
+$$
 
 ### Position Update
-\[
+$$
 x(t + \Delta t) = x(t) + v_{constrained} \cdot \Delta t
-\]
+$$
 
-Where \(\Delta t = dt \times 10^{-6}\) converts the simulation time step from microseconds to seconds.
+Where $\Delta t = dt \times 10^{-6}$ converts the simulation time step from microseconds to seconds.
 
 ## Default Parameters
 
 ### Common Parameters (Both Systems)
-- \(\omega_n = 200\) rad/s (Natural frequency/bandwidth)
-- \(a_{max} = 3 \times 10^5\) µm/s² (Maximum acceleration)
-- \(j_{max} = 10 \times 10^7\) µm/s³ (Maximum jerk)
-- \(v_{max} = 3 \times 10^4\) µm/s (Maximum velocity)
+- $\omega_n = 200$ rad/s (Natural frequency/bandwidth)
+- $a_{max} = 3 \times 10^5$ µm/s² (Maximum acceleration)
+- $j_{max} = 10 \times 10^7$ µm/s³ (Maximum jerk)
+- $v_{max} = 3 \times 10^4$ µm/s (Maximum velocity)
 
 ### Position Control Specific
-- \(\zeta = 0.55\) (Damping ratio for critically damped response)
+- $\zeta = 0.55$ (Damping ratio for critically damped response)
 
 ## Performance Characteristics
 
 ### Position Control
-- **Settling Time**: \(t_s \approx \frac{4}{\zeta\omega_n} = \frac{4}{0.55 \times 200} = 36.4\) ms
-- **Overshoot**: Minimal due to \(\zeta = 0.55 > 0.5\) (overdamped)
+- **Settling Time**: $t_s \approx \frac{4}{\zeta\omega_n} = \frac{4}{0.55 \times 200} = 36.4$ ms
+- **Overshoot**: Minimal due to $\zeta = 0.55 > 0.5$ (overdamped)
 - **Steady-State Error**: Zero for step position commands
 
 ### Velocity Control
-- **Time Constant**: \(\tau = \frac{1}{\omega_n} = \frac{1}{200} = 5\) ms
-- **Settling Time**: \(t_s \approx 4\tau = 20\) ms
+- **Time Constant**: $\tau = \frac{1}{\omega_n} = \frac{1}{200} = 5$ ms
+- **Settling Time**: $t_s \approx 4\tau = 20$ ms
 - **Steady-State Error**: Zero for step velocity commands
 
 ## Implementation Details
@@ -183,9 +183,9 @@ Where \(\Delta t = dt \times 10^{-6}\) converts the simulation time step from mi
 
 ### Time Conversion
 The simulation uses microsecond time steps, requiring conversion:
-\[
+$$
 \Delta t_{seconds} = \frac{dt_{microseconds}}{10^6}
-\]
+$$
 
 ### Numerical Stability
 Both systems use explicit integration with small time steps to maintain numerical stability. The jerk limiting provides additional stability by preventing discontinuous acceleration changes.

--- a/docs/theory/wire_theory.md
+++ b/docs/theory/wire_theory.md
@@ -4,185 +4,185 @@ The `WireModule` simulates the temperature distribution along the travelling wir
 
 ## Discretization
 
-The wire, with a total length \(L_{total}\), is divided into \(N\) segments, each of length \(\delta h\).
+The wire, with a total length $L_{total}$, is divided into $N$ segments, each of length $\delta h$.
 
-\[
+$$
 L_{total} = L_{buffer,bottom} + h_{workpiece} + L_{buffer,top}
-\]
-\[
+$$
+$$
 N = \text{max}(1, \text{int}(L_{total} / \delta h))
-\]
+$$
 
 Where:
-- \(L_{buffer,bottom}\): Length of the wire buffer below the workpiece.
-- \(H_{workpiece}\): Height of the workpiece.
-- \(L_{buffer,top}\): Length of the wire buffer above the workpiece.
-- \(\delta h\): Length of each wire segment.
+- $L_{buffer,bottom}$: Length of the wire buffer below the workpiece.
+- $H_{workpiece}$: Height of the workpiece.
+- $L_{buffer,top}$: Length of the wire buffer above the workpiece.
+- $\delta h$: Length of each wire segment.
 
-The lengths \(L_{buffer,bottom}\) and \(L_{buffer,top}\) define buffer zones at either end of the workpiece. While the primary interest is the temperature distribution within the workpiece section (\(H_{workpiece}\)), these buffer regions are essential for the accuracy of the simulation. They extend the modeled wire length beyond the workpiece itself, allowing for a more realistic calculation of heat transfer mechanisms such as conduction from adjacent segments and advection (due to wire travel). These mechanisms significantly influence the temperature profile within \(H_{workpiece}\), and the buffers help to ensure that the thermal conditions at the entry and exit points of the workpiece are properly represented, avoiding inaccuracies that could arise from artificial boundary effects.
+The lengths $L_{buffer,bottom}$ and $L_{buffer,top}$ define buffer zones at either end of the workpiece. While the primary interest is the temperature distribution within the workpiece section ($H_{workpiece}$), these buffer regions are essential for the accuracy of the simulation. They extend the modeled wire length beyond the workpiece itself, allowing for a more realistic calculation of heat transfer mechanisms such as conduction from adjacent segments and advection (due to wire travel). These mechanisms significantly influence the temperature profile within $H_{workpiece}$, and the buffers help to ensure that the thermal conditions at the entry and exit points of the workpiece are properly represented, avoiding inaccuracies that could arise from artificial boundary effects.
 
-The temperature of each segment \(i\) at time \(t\) is denoted as \(T_i(t)\).
+The temperature of each segment $i$ at time $t$ is denoted as $T_i(t)$.
 
 ## Heat Transfer Mechanisms
 
-The change in temperature \(\frac{dT_i}{dt}\) for each segment \(i\) is determined by the net effect of the following heat transfer mechanisms:
+The change in temperature $\frac{dT_i}{dt}$ for each segment $i$ is determined by the net effect of the following heat transfer mechanisms:
 
-\[
+$$
 \rho c_p V_i \frac{dT_i}{dt} = \dot{Q}_{cond,i} + \dot{Q}_{joule,i} + \dot{Q}_{plasma,i} - \dot{Q}_{conv,i} + \dot{Q}_{adv,i}
-\]
+$$
 
 Where:
-- \(\rho\): Density of the wire material (kg/m³)
-- \(c_p\): Specific heat capacity of the wire material (J/kg·K)
-- \(V_i\): Volume of segment \(i\) (\(S \cdot \delta h\)) (m³)
-- \(S\): Cross-sectional area of the wire (\(\pi r_{wire}^2\)) (m²)
-- \(r_{wire}\): Radius of the wire (m)
-- \(\delta h\): Length of the segment (m)
+- $\rho$: Density of the wire material (kg/m³)
+- $c_p$: Specific heat capacity of the wire material (J/kg·K)
+- $V_i$: Volume of segment $i$ ($S \cdot \delta h$) (m³)
+- $S$: Cross-sectional area of the wire ($\pi r_{wire}^2$) (m²)
+- $r_{wire}$: Radius of the wire (m)
+- $\delta h$: Length of the segment (m)
 
 The terms on the right-hand side are:
 
-### 1. Conduction (\(\dot{Q}_{cond,i}\))
+### 1. Conduction ($\dot{Q}_{cond,i}$)
 
-Heat transfer due to conduction between segment \(i\) and its adjacent segments \(i-1\) (upstream) and \(i+1\) (downstream). The net heat conducted into segment \(i\) is the sum of two components:
+Heat transfer due to conduction between segment $i$ and its adjacent segments $i-1$ (upstream) and $i+1$ (downstream). The net heat conducted into segment $i$ is the sum of two components:
 
-1.  **Heat flow from the upstream segment (\(i-1\)) to segment \(i\):**
-    This is driven by the temperature difference between segment \(i-1\) and segment \(i\).
-    \[
+1.  **Heat flow from the upstream segment ($i-1$) to segment $i$:**
+    This is driven by the temperature difference between segment $i-1$ and segment $i$.
+    $$
     \dot{Q}_{cond, i \leftarrow i-1} = k S \frac{T_{i-1} - T_i}{\delta h}
-    \]
+    $$
 
-2.  **Heat flow from the downstream segment (\(i+1\)) to segment \(i\):**
-    This is driven by the temperature difference between segment \(i+1\) and segment \(i\).
-    \[
+2.  **Heat flow from the downstream segment ($i+1$) to segment $i$:**
+    This is driven by the temperature difference between segment $i+1$ and segment $i$.
+    $$
     \dot{Q}_{cond, i \leftarrow i+1} = k S \frac{T_{i+1} - T_i}{\delta h}
-    \]
+    $$
 
-The total net conduction heat rate for segment \(i\), \(\dot{Q}_{cond,i}\), is the sum of these two flows:
-\[
+The total net conduction heat rate for segment $i$, $\dot{Q}_{cond,i}$, is the sum of these two flows:
+$$
 \dot{Q}_{cond,i} = \dot{Q}_{cond, i \leftarrow i-1} + \dot{Q}_{cond, i \leftarrow i+1} = k S \frac{(T_{i-1} - T_i) + (T_{i+1} - T_i)}{\delta h}
-\]
-This simplifies to the standard finite difference form for conduction, which is equivalent to using a central difference scheme for the second derivative of temperature with respect to position \(y\):
-\[
+$$
+This simplifies to the standard finite difference form for conduction, which is equivalent to using a central difference scheme for the second derivative of temperature with respect to position $y$:
+$$
 \dot{Q}_{cond,i} = k S \frac{T_{i-1} - 2T_i + T_{i+1}}{\delta h}
-\]
+$$
 
 Where:
-- \(k\): Thermal conductivity of the wire material (W/m·K)
-- \(S\): Cross-sectional area of the wire (m²)
-- \(\delta h\): Length of the segment (m)
-- \(T_{i-1}\), \(T_i\), \(T_{i+1}\): Temperatures of the upstream, current, and downstream segments, respectively.
+- $k$: Thermal conductivity of the wire material (W/m·K)
+- $S$: Cross-sectional area of the wire (m²)
+- $\delta h$: Length of the segment (m)
+- $T_{i-1}$, $T_i$, $T_{i+1}$: Temperatures of the upstream, current, and downstream segments, respectively.
 
-The module uses a coefficient `k_cond_coeff` = \(k S / \delta h\). Using this coefficient, the individual flows and the total net conduction can be expressed as:
-\[
+The module uses a coefficient `k_cond_coeff` = $k S / \delta h$. Using this coefficient, the individual flows and the total net conduction can be expressed as:
+$$
 \dot{Q}_{cond, i \leftarrow i-1} = \text{k\_cond\_coeff} \cdot (T_{i-1} - T_i)
-\]
-\[
+$$
+$$
 \dot{Q}_{cond, i \leftarrow i+1} = \text{k\_cond\_coeff} \cdot (T_{i+1} - T_i)
-\]
+$$
 And the total net conduction:
-\[
+$$
 \dot{Q}_{cond,i} = \text{k\_cond\_coeff} \cdot (T_{i-1} - 2T_i + T_{i+1})
-\]
+$$
 
 **Boundary Conditions for Conduction:**
--   At the wire entry (top, \(i=0\)): Dirichlet boundary condition, \(T_0 = T_{spool}\).
--   At the wire exit (bottom, \(i=N-1\)): Neumann boundary condition, \(\frac{dT}{dy} = 0\). This is approximated as:
-    \[
+-   At the wire entry (top, $i=0$): Dirichlet boundary condition, $T_0 = T_{spool}$.
+-   At the wire exit (bottom, $i=N-1$): Neumann boundary condition, $\frac{dT}{dy} = 0$. This is approximated as:
+    $$
     \dot{Q}_{cond,N-1} = k S \frac{T_{N-2} - T_{N-1}}{\delta h}
-    \]
+    $$
 
-### 2. Joule Heating (\(\dot{Q}_{joule,i}\))
+### 2. Joule Heating ($\dot{Q}_{joule,i}$)
 
 Heat generated within the segment due to the electrical current passing through it.
 
-\[
+$$
 \dot{Q}_{joule,i} = I^2 R_i = I^2 \rho_{elec}(T_i) \frac{\delta h}{S}
-\]
+$$
 
 Where:
-- \(I\): Electrical current (A)
-- \(R_i\): Electrical resistance of segment \(i\) (\(\Omega\))
-- \(\rho_{elec}(T_i)\): Electrical resistivity of the wire material at temperature \(T_i\) (\(\Omega \cdot m\)). This is temperature-dependent:
-  \[
+- $I$: Electrical current (A)
+- $R_i$: Electrical resistance of segment $i$ ($\Omega$)
+- $\rho_{elec}(T_i)$: Electrical resistivity of the wire material at temperature $T_i$ ($\Omega \cdot m$). This is temperature-dependent:
+  $$
   \rho_{elec}(T_i) = \rho_{elec,ref} (1 + \alpha_{\rho} (T_i - T_{ref}))
-  \]
-  - \(\rho_{elec,ref}\): Electrical resistivity at a reference temperature \(T_{ref}\) (e.g., 293.15 K).
-  - \(\alpha_{\rho}\): Temperature coefficient of resistivity (K⁻¹).
+  $$
+  - $\rho_{elec,ref}$: Electrical resistivity at a reference temperature $T_{ref}$ (e.g., 293.15 K).
+  - $\alpha_{\rho}$: Temperature coefficient of resistivity (K⁻¹).
 
-The implementation uses `0.5 * (I**2)` likely due to how power is distributed or a specific model assumption (e.g. average power over a cycle if current is AC, or a factor related to the simulation time step or energy deposition efficiency). The code uses: `0.5 * (I**2) * rho_T * (delta_y / S)`, where `rho_T` is \(\rho_{elec}(T_i)\).
+The implementation uses `0.5 * (I**2)` likely due to how power is distributed or a specific model assumption (e.g. average power over a cycle if current is AC, or a factor related to the simulation time step or energy deposition efficiency). The code uses: `0.5 * (I**2) * rho_T * (delta_y / S)`, where `rho_T` is $\rho_{elec}(T_i)$.
 
-### 3. Plasma Spot Heating (\(\dot{Q}_{plasma,i}\))
+### 3. Plasma Spot Heating ($\dot{Q}_{plasma,i}$)
 
 Heat input from the plasma discharge (spark) occurring at a specific location on the wire within the machining zone. This heating is applied only to the segment where the spark occurs.
 
-\[
+$$
 \dot{Q}_{plasma,i} = \eta_{plasma} V_{spark} I \delta_i
-\]
+$$
 
 Where:
-- \(idx\): Index of the segment where the spark occurs.
-- \(\eta_{plasma}\): Efficiency of plasma heating (fraction of total spark energy transferred to the wire).
-- \(V_{spark}\): Spark voltage (V).
+- $idx$: Index of the segment where the spark occurs.
+- $\eta_{plasma}$: Efficiency of plasma heating (fraction of total spark energy transferred to the wire).
+- $V_{spark}$: Spark voltage (V).
 
 This term is non-zero only for the segment `idx` corresponding to the spark location `y_spark`.
 
-### 4. Convection (\(\dot{Q}_{conv,i}\))
+### 4. Convection ($\dot{Q}_{conv,i}$)
 
 Heat loss from the wire segment to the surrounding dielectric fluid.
 
-\[
+$$
 \dot{Q}_{conv,i} = h_{eff} A_i (T_i - T_{dielectric})
-\]
+$$
 
 Where:
-- \(h_{eff}\): Effective heat transfer coefficient (W/m²·K). This can be dependent on the wire unwinding velocity \(v_{wire}\):
-  \[
+- $h_{eff}$: Effective heat transfer coefficient (W/m²·K). This can be dependent on the wire unwinding velocity $v_{wire}$:
+  $$
   h_{eff} = h_{conv} (1 + c_v \cdot v_{wire} + c_f \cdot f)
-  \]
-  (The code uses \(c=0.5\)).
-- \(A_i\): Surface area of the segment available for convection (\(2 \pi r_{wire} \delta h\)) (m²).
-- \(T_{dielectric}\): Temperature of the dielectric fluid (K).
+  $$
+  (The code uses $c=0.5$).
+- $A_i$: Surface area of the segment available for convection ($2 \pi r_{wire} \delta h$) (m²).
+- $T_{dielectric}$: Temperature of the dielectric fluid (K).
 
-### 5. Advection (\(\dot{Q}_{adv,i}\))
+### 5. Advection ($\dot{Q}_{adv,i}$)
 
-Heat is transported through segment \(i\) due to the physical movement (advection) of the wire. This process involves two components for segment \(i\), modeled using an upwind scheme:
+Heat is transported through segment $i$ due to the physical movement (advection) of the wire. This process involves two components for segment $i$, modeled using an upwind scheme:
 
-1.  **Heat Advected INTO Segment \(i\) (\(\dot{Q}_{adv,in,i}\)):**
-    This is the thermal energy carried into segment \(i\) by the wire material moving from the adjacent upstream segment (\(i-1\)).
-    \[
+1.  **Heat Advected INTO Segment $i$ ($\dot{Q}_{adv,in,i}$):**
+    This is the thermal energy carried into segment $i$ by the wire material moving from the adjacent upstream segment ($i-1$).
+    $$
     \dot{Q}_{adv,in,i} = \dot{m} c_p T_{i-1}
-    \]
-    Where \(\dot{m} = \rho S v_{wire}\) is the mass flow rate of the wire, \(\rho\) is the density, \(S\) is the cross-sectional area, \(v_{wire}\) is the wire velocity, \(c_p\) is the specific heat capacity, and \(T_{i-1}\) is the temperature of the upstream segment.
+    $$
+    Where $\dot{m} = \rho S v_{wire}$ is the mass flow rate of the wire, $\rho$ is the density, $S$ is the cross-sectional area, $v_{wire}$ is the wire velocity, $c_p$ is the specific heat capacity, and $T_{i-1}$ is the temperature of the upstream segment.
 
-2.  **Heat Advected OUT OF Segment \(i\) (\(\dot{Q}_{adv,out,i}\)):**
-    This is the thermal energy carried out of segment \(i\) by its own material as it moves downstream.
-    \[
+2.  **Heat Advected OUT OF Segment $i$ ($\dot{Q}_{adv,out,i}$):**
+    This is the thermal energy carried out of segment $i$ by its own material as it moves downstream.
+    $$
     \dot{Q}_{adv,out,i} = \dot{m} c_p T_i
-    \]
-    Where \(T_i\) is the temperature of the current segment \(i\).
+    $$
+    Where $T_i$ is the temperature of the current segment $i$.
 
-The net rate of heat gain by segment \(i\) due to advection, \(\dot{Q}_{adv,i}\), which appears in the main heat balance equation, is the difference between the heat advected in and the heat advected out:
-\[
+The net rate of heat gain by segment $i$ due to advection, $\dot{Q}_{adv,i}$, which appears in the main heat balance equation, is the difference between the heat advected in and the heat advected out:
+$$
 \dot{Q}_{adv,i} = \dot{Q}_{adv,in,i} - \dot{Q}_{adv,out,i} = \dot{m} c_p (T_{i-1} - T_i)
-\]
+$$
 This can also be expressed as:
-\[
+$$
 \dot{Q}_{adv,i} = (\rho_{wire} S c_p) (T_{i-1} - T_i)v_{wire}
-\]
+$$
 
 Where:
-- \(v_{wire}\): Wire unwinding velocity (m/s).
-- \(T_{i-1}\) represents the temperature of the material entering segment \(i\).
+- $v_{wire}$: Wire unwinding velocity (m/s).
+- $T_{i-1}$ represents the temperature of the material entering segment $i$.
 
 ## Update Equation
 
-The temperature \(T_i\) of each segment is updated at each simulation time step \(\Delta t\) using the calculated total rate of change \(\frac{dT_i}{dt}\):
+The temperature $T_i$ of each segment is updated at each simulation time step $\Delta t$ using the calculated total rate of change $\frac{dT_i}{dt}$:
 
-\[
+$$
 T_i(t + \Delta t) = T_i(t) + \left( \frac{\dot{Q}_{cond,i} + \dot{Q}_{joule,i} + \dot{Q}_{plasma,i} - \dot{Q}_{conv,i} + \dot{Q}_{adv,i}}{\rho c_p S \delta h} \right) \Delta t
-\]
+$$
 
-The denominator `self.denominator` = \(\rho c_p S \delta h\).
+The denominator `self.denominator` = $\rho c_p S \delta h$.
 
 ## Initialization and State
 
@@ -194,15 +194,15 @@ The denominator `self.denominator` = \(\rho c_p S \delta h\).
 
 -   `state.wire_temperature`: NumPy array holding the temperature of each segment.
 -   `self.spool_T`: Temperature of the wire on the spool (Dirichlet BC).
--   `self.seg_L`: Length of each segment (\(\delta h\)).
+-   `self.seg_L`: Length of each segment ($\delta h$).
 -   `self.delta_y`: Segment length in meters.
 -   `self.S`: Wire cross-sectional area.
 -   `self.A`: Segment surface area for convection.
 -   `self.k_cond_coeff`: Pre-calculated coefficient for conduction term.
--   `self.denominator`: Pre-calculated denominator for the \(\frac{dT}{dt}\) calculation (\(\rho c_p S \delta h\)).
+-   `self.denominator`: Pre-calculated denominator for the $\frac{dT}{dt}$ calculation ($\rho c_p S \delta h$).
 -   `dt_sim`: Simulation timestep (assumed 1 µs).
--   `state.current`: Machining current \(I\).
--   `state.voltage`: Machining voltage \(V_{spark}\).
+-   `state.current`: Machining current $I$.
+-   `state.voltage`: Machining voltage $V_{spark}$.
 -   `state.spark_status`: Array indicating if a spark is active (`[1, y_spark_pos, 0]`).
 -   `state.dielectric_temperature`: Temperature of the dielectric fluid.
 -   `state.wire_unwinding_velocity`: Speed of the wire.


### PR DESCRIPTION
## Summary
- update docs in `docs/theory` to use `$` and `$$` syntax

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848184b2e4c83318d8fc49a8cc74b47